### PR TITLE
PER-13: Remove the `vpn` user from the application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ RUN ln -snf /usr/share/zoneinfo/TIMEZONE /etc/localtime && echo $TIMEZONE > /etc
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install --quiet --assume-yes python3-pip aria2 cron curl unzip sudo poetry
 RUN pipx install poetry
 RUN useradd --create-home titan && echo "titan:titan" | chpasswd && adduser titan sudo
-RUN adduser --disabled-login vpn
-RUN usermod -aG titan vpn
-RUN usermod -aG vpn titan
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN mkdir -p "/mnt/plexdata/TV Shows"
 RUN mkdir -p "/mnt/plexdata/Downloads/tv_shows"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ The following environment variables needs to be set to use this application:
 | MOVIE_LOG_FILE             | Movie directory where the log file is located                                 | /var/log/watchy/movie.log        |
 | SEEDS_MINIMUM_COUNT        | Minimum amount of seeds required to start the download of the torrent file    | 3                                |
 | PROCESS_TIMEOUT            | Process timeout in seconds of the torrent file download command               | 3600                             |
-| VPN_USERNAME               | Username used for the VPN split tunnel connection                             | vpn                              |
 | TORRENT_LISTEN_PORT        | Torrent port to use for the torrent download connection                       | 7777                             |
 | TORRENT_DHT_LISTEN_PORT    | Torrent DHT port to use for the torrent download connection                   | 6800                             |
 | CONTENT_CLEANUP_DAYS       | Amount of days to wait before the content is deleted                          | 90                               |
@@ -73,4 +72,3 @@ environment by completing the following steps:
    environment:
 
    `docker-compose down`
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,4 @@ services:
       - ./:/app/watchy
       - ./plexdata:/mnt/plexdata
     env_file:
-      - .env.docker
+      - .env

--- a/watchy/magnet.py
+++ b/watchy/magnet.py
@@ -4,39 +4,69 @@ import subprocess
 logger = logging.getLogger(__name__)
 
 
-def download_magnet_link(download_entry, download_directory, seeds_minimum_count, process_timeout, vpn_username,
-                         torrent_listen_port, torrent_dht_listen_port):
+def download_magnet_link(
+    download_entry,
+    download_directory,
+    seeds_minimum_count,
+    process_timeout,
+    torrent_listen_port,
+    torrent_dht_listen_port,
+):
     # Download the torrent file using the magnet link
     try:
         # Download only torrents that have a certain amount of seeds or more
         if download_entry["seeds"] >= seeds_minimum_count:
             logger.info(
-                "starting download for {0} (seeds_count={1})".format(download_entry["title"], download_entry["seeds"]))
+                "starting download for {0} (seeds_count={1})".format(
+                    download_entry["title"], download_entry["seeds"]
+                )
+            )
             subprocess.check_output(
-                "sudo -u " + vpn_username + " -i -- aria2c -d " + download_directory + " --disable-ipv6 --bt-stop-timeout=" + str(
-                    process_timeout + 100) + " --listen-port=" + torrent_listen_port + " --dht-listen-port=" + torrent_dht_listen_port + " --seed-time=0 " + str(
-                    download_entry["magnet"]), timeout=process_timeout, shell=True)
+                "aria2c -d "
+                + download_directory
+                + " --disable-ipv6 --bt-stop-timeout="
+                + str(process_timeout + 100)
+                + " --listen-port="
+                + torrent_listen_port
+                + " --dht-listen-port="
+                + torrent_dht_listen_port
+                + " --seed-time=0 "
+                + str(download_entry["magnet"]),
+                timeout=process_timeout,
+                shell=True,
+            )
             return_code = 0
-            logger.info("completed download for {0} (return_code={1})".format(download_entry["title"], return_code))
+            logger.info(
+                "completed download for {0} (return_code={1})".format(
+                    download_entry["title"], return_code
+                )
+            )
             return return_code
         else:
             # Return code 7 if the amount of seeds is below than a certain amount
             return_code = 7
             logger.info(
-                "less than {0} seeds for {1} (return_code={2})".format(seeds_minimum_count, download_entry["title"],
-                                                                       return_code))
+                "less than {0} seeds for {1} (return_code={2})".format(
+                    seeds_minimum_count, download_entry["title"], return_code
+                )
+            )
             return return_code
     except subprocess.CalledProcessError as error:
         # Return code 7 if the aria2c command line application crashes
         if error.returncode == 7:
             return_code = 7
             logger.error(
-                "aria2c command crashed during execution for {0} (return_code={1})".format(download_entry["title"],
-                                                                                           return_code))
+                "aria2c command crashed during execution for {0} (return_code={1})".format(
+                    download_entry["title"], return_code
+                )
+            )
             return return_code
     except subprocess.TimeoutExpired as error:
         # Return code 2 if the aria2c command timeout
         return_code = 2
-        logger.error("aria2c command timeout during execution for {0} (return_code={1})".format(download_entry["title"],
-                                                                                                return_code))
+        logger.error(
+            "aria2c command timeout during execution for {0} (return_code={1})".format(
+                download_entry["title"], return_code
+            )
+        )
         return return_code

--- a/watchy/main.py
+++ b/watchy/main.py
@@ -51,7 +51,6 @@ tmdb_username = os.environ.get("TMDB_USERNAME")
 tmdb_password = os.environ.get("TMDB_PASSWORD")
 tmdb_api_key = os.environ.get("TMDB_API_KEY")
 tmdb_account_id = os.environ.get("TMDB_ACCOUNT_ID")
-vpn_username = os.environ.get("VPN_USERNAME")
 torrent_listen_port = os.environ.get("TORRENT_LISTEN_PORT")
 torrent_dht_listen_port = os.environ.get("TORRENT_DHT_LISTEN_PORT")
 
@@ -205,7 +204,6 @@ def movie():
                                 download_directory=movies_download_directory,
                                 seeds_minimum_count=seeds_minimum_count,
                                 process_timeout=process_timeout,
-                                vpn_username=vpn_username,
                                 torrent_listen_port=torrent_listen_port,
                                 torrent_dht_listen_port=torrent_dht_listen_port,
                             )
@@ -332,7 +330,6 @@ def tv_show():
                         download_directory=tv_shows_download_directory,
                         seeds_minimum_count=seeds_minimum_count,
                         process_timeout=process_timeout,
-                        vpn_username=vpn_username,
                         torrent_listen_port=torrent_listen_port,
                         torrent_dht_listen_port=torrent_dht_listen_port,
                     )


### PR DESCRIPTION
# Changes

- Remove the `vpn_username` parameter from the `download_magnet_link` in the `main.py` file
- Remove the `VPN_USERNAME` environment variable configuration in the `README.md` file
- Remove the unused `vpn` user and related group modifications in the `Dockerfile` file
- Format the `magnet.py` file
- Update the `docker-compose.yml` file environment variable configuration to use `.env` instead `.env.docker`

# Additional Notes

- This change removes the need to use a VPN for downloading movies and TV shows
- This change is made for reducing the costs as it costs around 10 USD $ / year for the Private Internet Access (PIA) VPN solution
