### PR TITLE
PER-260 chore(folder): remove `sudo` command for setting up the files ownership

### DIFF
--- a/watchy/folder.py
+++ b/watchy/folder.py
@@ -85,7 +85,9 @@ def move_content_file(
         try:
             content_download_file = max(content_download_files, key=lambda d: d["size"])
         except ValueError:
-            error_message = "Unable to move the content as the download directory is empty"
+            error_message = (
+                "Unable to move the content as the download directory is empty"
+            )
             logger.error(error_message)
             raise ValueError(error_message)
         # Move file only if the correct file is found with the right extension
@@ -192,7 +194,10 @@ def cleanup_content_folder(content_folder, content_cleanup_days):
                 try:
                     os.remove(file_path)
                     deleted_content_files.append(file_path)
-                    logger.info("successfully completed the deletion of the following file: %s", file_path)
+                    logger.info(
+                        "successfully completed the deletion of the following file: %s",
+                        file_path,
+                    )
                 except:
                     logger.error("unable to delete the following file: %s", file_path)
     return deleted_content_files

--- a/watchy/folder.py
+++ b/watchy/folder.py
@@ -93,7 +93,7 @@ def move_content_file(
             # Update the file owner to use the main user
             current_user = getpass.getuser()
             subprocess.check_output(
-                "sudo chown -R "
+                "chown -R "
                 + current_user
                 + ":"
                 + current_user


### PR DESCRIPTION
## Changes
- style(folder): reformatted long error and info logger messages to use multi-line style for improved readability
- fix(folder): removed unnecessary `sudo` from `chown` command when changing file ownership

## Additional Notes
- Ensure no scripts expect `sudo` for `chown` operations in this folder.
- Logger messages are now easier to read in logs and reviews.
